### PR TITLE
chore: set up semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+cache:
+  directories:
+    - ~/.npm
+notifications:
+  email: false
+node_js:
+  - '10'
+after_success:
+  - npm run travis-deploy-once "npm run semantic-release"
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "rhymes",
-  "version": "1.0.1",
+  "version": "0.0.0-development",
   "description": "Give me an English word and I'll give you a list of rhymes",
   "main": "index.js",
   "scripts": {
-    "test": "standard --format && mocha"
+    "test": "standard --format && mocha",
+    "travis-deploy-once": "travis-deploy-once",
+    "semantic-release": "semantic-release"
   },
   "repository": "github:zeke/rhymes",
   "keywords": [
@@ -23,6 +25,8 @@
   },
   "devDependencies": {
     "mocha": "^2.2.5",
-    "standard": "^4.5.2"
+    "standard": "^4.5.2",
+    "travis-deploy-once": "^5.0.9",
+    "semantic-release": "^15.12.4"
   }
 }


### PR DESCRIPTION
Along with the https://github.com/apps/semantic-pull-requests bot, this change will enable npm publishes to happen automatically on Travis.