### PR TITLE
v2.0.1 - use an updated cmudict library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
-var dict = require('cmu-pronouncing-dictionary')
+var cmudict = require('@lunarisapp/cmudict')
+var dict = cmudict.dict()
 
 var own = {}.hasOwnProperty
 
 var words = []
 
 Object.keys(dict).forEach(function(word) {
-  words.push({word: word, pron: dict[word]})
+  words.push({word: word, pron: dict[word][0].join(' ')})
 })
 
 module.exports = rhymes
@@ -21,7 +22,7 @@ function rhymes(value) {
 
   if (!own.call(dict, value)) return results
 
-  pron = dict[value]
+  pron = dict[value][0].join(' ')
 
   words.forEach(check)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhymes",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Give me an English word and I'll give you a list of rhymes",
   "license": "ISC",
   "keywords": [
@@ -22,7 +22,7 @@
     "index.js"
   ],
   "dependencies": {
-    "cmu-pronouncing-dictionary": "^2.0.0"
+    "@lunarisapp/cmudict": "^1.0.0"
   },
   "devDependencies": {
     "nyc": "^15.0.0",

--- a/test.js
+++ b/test.js
@@ -29,12 +29,12 @@ test('rhymes', function(t) {
       'denki',
       'dinky',
       'donkey',
-      'donkey', // Different pronunciation
       'francie',
-      'franke',
       'frankie',
       'hankey',
-      'hanky'
+      'hanky',
+      'helsinki',
+      'honky'
     ],
     'monkey: should result in rhymes!'
   )


### PR DESCRIPTION
[cmu-pronouncing-dictionary](https://github.com/words/cmu-pronouncing-dictionary#readme) hasn't been updated for 4 years, although the dictionary itself is being actively maintained and expanded, and got quite a few [updates](https://github.com/cmusphinx/cmudict/commits/master/) since.

The PR replaces the javascript interface with the one that has an updated dataset.